### PR TITLE
Add customisation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gotham-cors-middleware"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Andy Bell <andy.bell.github@gmail.com>"]
 description = "A small crate to add basic CORS functionality to Gotham apps"
 repository = "https://github.com/simpleweb/gotham-cors-middleware"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This library is aimed to provide CORS functionality to [Gotham.rs](https://gotham.rs/) servers.
 
-Currently this is a very simple implementation with no customisability.
+Currently this is a very simple implementation with limited customisability.
+
+Requires rust 1.26 or later.
 
 Usage:
 ```rust
@@ -18,7 +20,7 @@ use gotham::router::Router;
 pub fn router() -> Router {
     let (chain, pipeline) = single_pipeline(
         new_pipeline()
-            .add(CORSMiddleware)
+            .add(CORSMiddleware::default())
             .build(),
     );
 
@@ -30,5 +32,6 @@ pub fn router() -> Router {
 
 Roadmap:
 - [x] Add integration tests
-- [ ] Add builder that would allow header customisation
-- [ ] Add documentation
+- [x] Add builder that would allow header customisation
+- [x] Add documentation
+- [ ] See how next version of Gotham requires changes to middeware structure

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,15 @@ pub struct CORSMiddleware {
 }
 
 impl CORSMiddleware {
+    /// Create a new CORSMiddleware with custom methods,
+    /// origin and max_age properties.
+    ///
+    /// Expects methods to be a Vec of hyper::Method enum
+    /// values, origin to be an Option containing a String
+    /// (so allows for None values - which defaults to
+    /// returning the sender origin on request or returning
+    /// a string of "*" - see the call function source) and
+    /// max age to be a u32 value.
     pub fn new(methods: Vec<Method>, origin: Option<String>, max_age: u32) -> CORSMiddleware {
         CORSMiddleware {
             methods,
@@ -67,6 +76,12 @@ impl CORSMiddleware {
         }
     }
 
+    /// Creates a new CORSMiddleware with what is currently
+    /// the "default" values for methods/origin/max_age.
+    ///
+    /// This is based off the values that were used previously
+    /// before they were customisable. If you need different
+    /// values, use the new() function.
     pub fn default() -> CORSMiddleware {
         let methods = vec![
             Method::Delete,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,42 @@ impl CORSMiddleware {
     /// returning the sender origin on request or returning
     /// a string of "*" - see the call function source) and
     /// max age to be a u32 value.
+    ///
+    /// Example of use:
+    /// ```rust
+    /// extern crate gotham;
+    /// extern crate gotham_cors_middleware;
+    /// extern crate hyper;
+    ///
+    /// use gotham::pipeline::new_pipeline;
+    /// use gotham_cors_middleware::CORSMiddleware;
+    /// use gotham::pipeline::single::single_pipeline;
+    /// use gotham::router::builder::*;
+    /// use gotham::router::Router;
+    /// use hyper::Method;
+    ///
+    /// fn create_custom_middleware() -> CORSMiddleware {
+    ///     let methods = vec![Method::Delete, Method::Get, Method::Head, Method::Options];
+    ///
+    ///     let max_age = 1000;
+    ///
+    ///     let origin = Some("http://www.example.com".to_string());
+    ///
+    ///     CORSMiddleware::new(methods, origin, max_age)
+    /// }
+    ///
+    /// pub fn router() -> Router {
+    ///     let (chain, pipeline) = single_pipeline(
+    ///         new_pipeline()
+    ///             .add(create_custom_middleware())
+    ///             .build()
+    ///     );
+    ///
+    ///     build_router(chain, pipeline, |route| {
+    ///         // Routes
+    ///     })
+    /// }
+    /// ```
     pub fn new(methods: Vec<Method>, origin: Option<String>, max_age: u32) -> CORSMiddleware {
         CORSMiddleware {
             methods,
@@ -96,11 +132,7 @@ impl CORSMiddleware {
         let origin = None;
         let max_age = 86400;
 
-        CORSMiddleware {
-            methods,
-            origin,
-            max_age,
-        }
+        CORSMiddleware::new(methods, origin, max_age)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,8 @@
+//! Library aimed at providing CORS functionality
+//! for Gotham based servers.
+//!
+//! Currently a very basic implementation with
+//! limited customisability.
 #[macro_use]
 extern crate gotham_derive;
 
@@ -18,6 +23,34 @@ use hyper::Method;
 use std::option::Option;
 use unicase::Ascii;
 
+/// Struct to perform the necessary CORS
+/// functionality needed. Allows some
+/// customisation through use of the
+/// new() function.
+///
+/// Example of use:
+/// ```rust
+/// extern crate gotham;
+/// extern crate gotham_cors_middleware;
+///
+/// use gotham::pipeline::new_pipeline;
+/// use gotham_cors_middleware::CORSMiddleware;
+/// use gotham::pipeline::single::single_pipeline;
+/// use gotham::router::builder::*;
+/// use gotham::router::Router;
+///
+/// pub fn router() -> Router {
+///     let (chain, pipeline) = single_pipeline(
+///         new_pipeline()
+///             .add(CORSMiddleware::default())
+///             .build()
+///     );
+///
+///     build_router(chain, pipeline, |route| {
+///         // Routes
+///     })
+/// }
+/// ```
 #[derive(Clone, NewMiddleware, Debug, PartialEq)]
 pub struct CORSMiddleware {
     methods: Vec<Method>,


### PR DESCRIPTION
Updates CORSMiddleware with two new functions
needed to create new instances of the middleware
allowing customisation of the headers, with a
"default" function providing an instance of the
middleware that functions the same as in the
0.1.0 version, and a "new" function that allows
the end user to use differing values as they
find the need to in their use case.